### PR TITLE
Update more parquet APIs to use u64

### DIFF
--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -431,7 +431,7 @@ impl ChunkReader for ArrowColumnChunkData {
         ))
     }
 
-    fn get_bytes(&self, _start: u64, _length: u64`) -> Result<Bytes> {
+    fn get_bytes(&self, _start: u64, _length: u64) -> Result<Bytes> {
         unimplemented!()
     }
 }

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -431,7 +431,7 @@ impl ChunkReader for ArrowColumnChunkData {
         ))
     }
 
-    fn get_bytes(&self, _start: u64, _length: usize) -> Result<Bytes> {
+    fn get_bytes(&self, _start: u64, _length: u64`) -> Result<Bytes> {
         unimplemented!()
     }
 }

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -138,7 +138,7 @@ impl AsyncFileReader for Box<dyn AsyncFileReader + '_> {
 }
 
 impl<T: AsyncFileReader + MetadataFetch + AsyncRead + AsyncSeek + Unpin> MetadataSuffixFetch for T {
-    fn fetch_suffix(&mut self, suffix: usize) -> BoxFuture<'_, Result<Bytes>> {
+    fn fetch_suffix(&mut self, suffix: u64) -> BoxFuture<'_, Result<Bytes>> {
         async move {
             self.seek(SeekFrom::End(-(suffix as i64))).await?;
             let mut buf = Vec::with_capacity(suffix);
@@ -1058,6 +1058,7 @@ impl ChunkReader for ColumnChunkData {
     }
 
     fn get_bytes(&self, start: u64, length: usize) -> Result<Bytes> {
+        let length: usize = length.try_into()?;
         Ok(self.get(start)?.slice(..length))
     }
 }

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -1057,7 +1057,7 @@ impl ChunkReader for ColumnChunkData {
         Ok(self.get(start)?.reader())
     }
 
-    fn get_bytes(&self, start: u64, length: usize) -> Result<Bytes> {
+    fn get_bytes(&self, start: u64, length: u64) -> Result<Bytes> {
         let length: usize = length.try_into()?;
         Ok(self.get(start)?.slice(..length))
     }

--- a/parquet/src/arrow/async_reader/store.rs
+++ b/parquet/src/arrow/async_reader/store.rs
@@ -161,9 +161,9 @@ impl ParquetObjectReader {
 }
 
 impl MetadataSuffixFetch for &mut ParquetObjectReader {
-    fn fetch_suffix(&mut self, suffix: usize) -> BoxFuture<'_, Result<Bytes>> {
+    fn fetch_suffix(&mut self, suffix: u64) -> BoxFuture<'_, Result<Bytes>> {
         let options = GetOptions {
-            range: Some(GetRange::Suffix(suffix as u64)),
+            range: Some(GetRange::Suffix(suffix)),
             ..Default::default()
         };
         self.spawn(|store, path| {

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -318,9 +318,9 @@ impl Sbbf {
 
         let buffer = match column_metadata.bloom_filter_length() {
             Some(length) => {
-                let length: u64 =  length.try_into()?;
+                let length: u64 = length.try_into()?;
                 reader.get_bytes(offset, length)
-            },
+            }
             None => reader.get_bytes(offset, SBBF_HEADER_SIZE_ESTIMATE),
         }?;
 

--- a/parquet/src/errors.rs
+++ b/parquet/src/errors.rs
@@ -46,12 +46,12 @@ pub enum ParquetError {
     ArrowError(String),
     /// Error when the requested column index is more than the
     /// number of columns in the row group
-    IndexOutOfBound(usize, usize),
+    IndexOutOfBound(u64, u64),
     /// An external error variant
     External(Box<dyn Error + Send + Sync>),
-    /// Returned when a function needs more data to complete properly. The `usize` field indicates
+    /// Returned when a function needs more data to complete properly. The `u64` field indicates
     /// the total number of bytes required, not the number of additional bytes.
-    NeedMoreData(usize),
+    NeedMoreData(u64),
 }
 
 impl std::fmt::Display for ParquetError {

--- a/parquet/src/file/footer.rs
+++ b/parquet/src/file/footer.rs
@@ -76,6 +76,6 @@ pub fn decode_metadata(buf: &[u8]) -> Result<ParquetMetaData> {
     since = "53.1.0",
     note = "Use ParquetMetaDataReader::decode_footer_tail"
 )]
-pub fn decode_footer(slice: &[u8; FOOTER_SIZE]) -> Result<usize> {
+pub fn decode_footer(slice: &[u8; FOOTER_SIZE as usize]) -> Result<u64> {
     ParquetMetaDataReader::decode_footer_tail(slice).map(|f| f.metadata_length())
 }

--- a/parquet/src/file/metadata/mod.rs
+++ b/parquet/src/file/metadata/mod.rs
@@ -1103,9 +1103,9 @@ impl ColumnChunkMetaData {
     }
 
     /// Returns the range for the offset index if any
-    pub(crate) fn column_index_range(&self) -> Option<Range<usize>> {
-        let offset = usize::try_from(self.column_index_offset?).ok()?;
-        let length = usize::try_from(self.column_index_length?).ok()?;
+    pub(crate) fn column_index_range(&self) -> Option<Range<u64>> {
+        let offset = u64::try_from(self.column_index_offset?).ok()?;
+        let length = u64::try_from(self.column_index_length?).ok()?;
         Some(offset..(offset + length))
     }
 
@@ -1120,9 +1120,9 @@ impl ColumnChunkMetaData {
     }
 
     /// Returns the range for the offset index if any
-    pub(crate) fn offset_index_range(&self) -> Option<Range<usize>> {
-        let offset = usize::try_from(self.offset_index_offset?).ok()?;
-        let length = usize::try_from(self.offset_index_length?).ok()?;
+    pub(crate) fn offset_index_range(&self) -> Option<Range<u64>> {
+        let offset = u64::try_from(self.offset_index_offset?).ok()?;
+        let length = u64::try_from(self.offset_index_length?).ok()?;
         Some(offset..(offset + length))
     }
 

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -423,11 +423,7 @@ impl ParquetMetaDataReader {
     /// See [`Self::with_prefetch_hint`] for a discussion of how to reduce the number of fetches
     /// performed by this function.
     #[cfg(all(feature = "async", feature = "arrow"))]
-    pub async fn try_load<F: MetadataFetch>(
-        &mut self,
-        mut fetch: F,
-        file_size: u64,
-    ) -> Result<()> {
+    pub async fn try_load<F: MetadataFetch>(&mut self, mut fetch: F, file_size: u64) -> Result<()> {
         let (metadata, remainder) = self.load_metadata(&mut fetch, file_size).await?;
 
         self.metadata = Some(metadata);

--- a/parquet/src/file/page_index/index_reader.rs
+++ b/parquet/src/file/page_index/index_reader.rs
@@ -39,7 +39,10 @@ pub(crate) fn acc_range(a: Option<Range<u64>>, b: Option<Range<u64>>) -> Option<
 }
 
 /// Computes the covering range of two optional ranges of `usize`
-pub(crate) fn acc_range_usize(a: Option<Range<usize>>, b: Option<Range<usize>>) -> Option<Range<usize>> {
+pub(crate) fn acc_range_usize(
+    a: Option<Range<usize>>,
+    b: Option<Range<usize>>,
+) -> Option<Range<usize>> {
     match (a, b) {
         (Some(a), Some(b)) => Some(a.start.min(b.start)..a.end.max(b.end)),
         (None, x) | (x, None) => x,

--- a/parquet/src/file/page_index/index_reader.rs
+++ b/parquet/src/file/page_index/index_reader.rs
@@ -31,7 +31,15 @@ use std::ops::Range;
 /// Computes the covering range of two optional ranges
 ///
 /// For example `acc_range(Some(7..9), Some(1..3)) = Some(1..9)`
-pub(crate) fn acc_range(a: Option<Range<usize>>, b: Option<Range<usize>>) -> Option<Range<usize>> {
+pub(crate) fn acc_range(a: Option<Range<u64>>, b: Option<Range<u64>>) -> Option<Range<u64>> {
+    match (a, b) {
+        (Some(a), Some(b)) => Some(a.start.min(b.start)..a.end.max(b.end)),
+        (None, x) | (x, None) => x,
+    }
+}
+
+/// Computes the covering range of two optional ranges of `usize`
+pub(crate) fn acc_range_usize(a: Option<Range<usize>>, b: Option<Range<usize>>) -> Option<Range<usize>> {
     match (a, b) {
         (Some(a), Some(b)) => Some(a.start.min(b.start)..a.end.max(b.end)),
         (None, x) | (x, None) => x,

--- a/parquet/src/file/reader.rs
+++ b/parquet/src/file/reader.rs
@@ -23,7 +23,6 @@ use bytes::{Buf, Bytes};
 use std::fs::File;
 use std::io::{BufReader, Seek, SeekFrom};
 use std::{io::Read, sync::Arc};
-
 use crate::bloom_filter::Sbbf;
 use crate::column::page::PageIterator;
 use crate::column::{page::PageReader, reader::ColumnReader};
@@ -77,7 +76,7 @@ pub trait ChunkReader: Length + Send + Sync {
     ///
     /// Similarly to [`Self::get_read`], this method may have side-effects on
     /// previously returned readers.
-    fn get_bytes(&self, start: u64, length: usize) -> Result<Bytes>;
+    fn get_bytes(&self, start: u64, length: u64) -> Result<Bytes>;
 }
 
 impl Length for File {
@@ -95,11 +94,13 @@ impl ChunkReader for File {
         Ok(BufReader::new(self.try_clone()?))
     }
 
-    fn get_bytes(&self, start: u64, length: usize) -> Result<Bytes> {
-        let mut buffer = Vec::with_capacity(length);
+    fn get_bytes(&self, start: u64, length: u64) -> Result<Bytes> {
+        let cap: usize = length.try_into()?;
+        let mut buffer = Vec::with_capacity(cap);
         let mut reader = self.try_clone()?;
         reader.seek(SeekFrom::Start(start))?;
         let read = reader.take(length as _).read_to_end(&mut buffer)?;
+        let read = read as u64;
 
         if read != length {
             return Err(eof_err!(
@@ -126,8 +127,9 @@ impl ChunkReader for Bytes {
         Ok(self.slice(start..).reader())
     }
 
-    fn get_bytes(&self, start: u64, length: usize) -> Result<Bytes> {
-        let start = start as usize;
+    fn get_bytes(&self, start: u64, length: u64) -> Result<Bytes> {
+        let start: usize = start.try_into()?;
+        let length: usize = length.try_into()?;
         Ok(self.slice(start..start + length))
     }
 }

--- a/parquet/src/file/reader.rs
+++ b/parquet/src/file/reader.rs
@@ -19,10 +19,6 @@
 //! readers to read individual column chunks, or access record
 //! iterator.
 
-use bytes::{Buf, Bytes};
-use std::fs::File;
-use std::io::{BufReader, Seek, SeekFrom};
-use std::{io::Read, sync::Arc};
 use crate::bloom_filter::Sbbf;
 use crate::column::page::PageIterator;
 use crate::column::{page::PageReader, reader::ColumnReader};
@@ -31,6 +27,10 @@ use crate::file::metadata::*;
 pub use crate::file::serialized_reader::{SerializedFileReader, SerializedPageReader};
 use crate::record::reader::RowIter;
 use crate::schema::types::Type as SchemaType;
+use bytes::{Buf, Bytes};
+use std::fs::File;
+use std::io::{BufReader, Seek, SeekFrom};
+use std::{io::Read, sync::Arc};
 
 use crate::basic::Type;
 


### PR DESCRIPTION
Note: -Targets https://github.com/apache/arrow-rs/pull/7371

This gives some idea of what other APIs would need to be changed to fully and properly support > 4GB files in WASM (32 bit `usize`)

I may be mistaken, but I wanted to get this PR up for discussion